### PR TITLE
editing toml pytest spelling mistake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 [project.scripts]
 GroupB-tool="Gene_Model_Summariser.cli:app"
 
-[tool.pytest.init_options]
+[tool.pytest.ini_options]
 testpaths=["tests"]
 addopts= ["-q"]
 


### PR DESCRIPTION
editing [tool.pytest.init_options] to [tool.pytest.ini_options] so pytest can see it 